### PR TITLE
Changes to fix build and add dependencySourcesZip

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,12 @@ def _url = 'http://support.dell.com'
 def _arch = 'x86_64'
 def _os = 'LINUX'
 def _release = 1
+def _sourcePaths=[]
 
 
 sourceCompatibility = 1.8
 version = "${version}"
+dockerTag = "${dockerTag}"
 group = 'com.dell.isg.smi'
 
 buildscript {
@@ -87,6 +89,9 @@ springBoot {
 }
 
 repositories {
+	maven {url "http://repository.springsource.com/maven/bundles/release" }
+    maven {url "http://repository.springsource.com/maven/bundles/external"}
+	maven {url "${artifactory_contextUrl}/${dependency_repo}"}
 	maven {url "${artifactory_contextUrl}/libs-release"}
 	maven {url "https://plugins.gradle.org/m2/"}
 	maven {url "http://maven.vaadin.com/vaadin-addons" }
@@ -95,15 +100,15 @@ repositories {
 }
 
 dependencies {
-	compile 'com.dell.isg.smi:wsmanlib:1.0.29'
+	compile 'com.dell.isg.smi:wsmanlib:1.0-SNAPSHOT'
 	compile 'com.dell.isg.smi:wsmanclient:1.0.28'
-    compile 'com.dell.isg.smi:racadmlib:1.0.16'
-  	compile 'com.dell.isg.smi:commons-elm:1.0.76'
-    compile group: 'com.dell.isg.smi', name: 'commons-utilities', version: '1.0.26'
-	compile 'com.dell.isg.smi:commons-model:1.0.81'
+    compile 'com.dell.isg.smi:racadmlib:1.0-SNAPSHOT'
+  	compile 'com.dell.isg.smi:commons-elm:1.0-SNAPSHOT'
+    compile group: 'com.dell.isg.smi', name: 'commons-utilities', version: '1.0-SNAPSHOT'
+	compile 'com.dell.isg.smi:commons-model:1.0-SNAPSHOT'
 	//compile project(':smi-lib-commons-model')
-	compile 'com.dell.isg.smi:adapter-server:1.0.34'
-	compile 'com.dell.isg.smi:adapter-chassis:1.0.12'
+	compile 'com.dell.isg.smi:adapter-server:1.0-SNAPSHOT'
+	compile 'com.dell.isg.smi:adapter-chassis:1.0-SNAPSHOT'
 	compile "org.springframework.boot:spring-boot-starter-web"
 	compile "org.springframework.boot:spring-boot-starter-tomcat"
     compile "org.springframework.boot:spring-boot-starter-actuator"
@@ -117,7 +122,7 @@ dependencies {
 	compile group: 'io.springfox', name: 'springfox-swagger-ui', version: '+'
     compile group: 'com.jcraft', name: 'jsch', version: '+'
     compile group: 'com.github.cverges.expect4j', name: 'expect4j', version: '+'
-    runtime group: 'wiseman', name: 'wiseman', version: '+'
+    runtime group: 'wiseman', name: 'wiseman', version: '2.0'
 	testCompile group: 'junit', name: 'junit', version: '+'
 	testCompile("org.springframework.boot:spring-boot-starter-test")
 	
@@ -232,4 +237,52 @@ task generateDeb(type: Deb){
 	    into  '/etc/systemd/system'
     }
 	link('/etc/systemd/system/multi-user.target.wants/dell-device-discovery.service', '/etc/systemd/system/dell-device-discovery.service')
+}
+
+
+eclipse {
+    project{
+    	buildCommand 'org.eclipse.buildship.core.gradleprojectbuilder'
+    		
+		// assign natures in a groovy fashion:
+		natures = ['org.eclipse.buildship.core.gradleprojectnature']
+    }
+    
+    classpath {
+       downloadSources=true
+    }
+}
+
+
+task buildSourcePathsArray(dependsOn: 'eclipseClasspath' ){
+	doLast{
+		def classpathFile = file('.classpath')
+		if( classpathFile.exists() ) {
+			def cpXml = new XmlParser().parse(classpathFile)
+			cpXml.classpathentry.each {
+				if('lib' == it.@kind ) {
+					if( it.@sourcepath == null ){
+						println 'missing source jar for:' + it.@path
+					}
+					else{
+					 	_sourcePaths.add(it.@sourcepath)
+					}
+				}
+			}
+		}
+		 
+		def arrayLength = _sourcePaths.size()
+		println 'sourcePaths length is:' + arrayLength
+	}
+}
+
+
+task dependencySourcesZip(type: Zip, dependsOn: 'buildSourcePathsArray' ) {
+	destinationDir = project.file('build/distributions')
+	destinationDir.mkdirs()
+	baseName = "smi-service-virtualnetwork-dependency-sources"
+	version = "${dockerTag}"
+	outputs.upToDateWhen { false }
+ 
+    from _sourcePaths
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,7 @@
 version=1.0
+dockerTag=devel
 artifactory_contextUrl=https://gtie-artifactory.us.dell.com/artifactory
+dependency_repo=libs-snapshot
 buildInfo.licenseControl.runChecks=true
 buildInfo.licenseControl.autoDiscover=true
 buildInfo.build.name=com.dell.isg.smi:service-device-discovery


### PR DESCRIPTION
After last merge, build was failing to resolve dependencies for model due to incorrect version.  Changed to use snapshots, and also build dependency sources zip. 